### PR TITLE
Hdl 285 paypal sdk header: Fixing Case Sensitivity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,5 @@
+## 1.0.1
+* Fix Case Sensitivity of Content Type for deserialization process
+
 ## 1.0.0
 * First Release

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2009-2019 PayPal, Inc.
+Copyright (c) 2009-2021 PayPal, Inc.
 
 Permission is hereby granted, free of charge, to any person
 obtaining a copy of this software and associated documentation

--- a/lib/paypalhttp/encoder.js
+++ b/lib/paypalhttp/encoder.js
@@ -37,6 +37,8 @@ class Encoder {
     if (!contentType) {
       throw new Error('HttpRequest does not have Content-Type header set');
     }
+    // Forcing Lowercase to ensure deserializing happens properly
+    contentType = contentType.toLowerCase();
 
     let encoder = this._encoder(contentType);
 

--- a/lib/paypalhttp/http_client.js
+++ b/lib/paypalhttp/http_client.js
@@ -53,7 +53,11 @@ class HttpClient {
 
     Object.keys(headers).forEach(function (key) {
       if (key != null) {
-        formattedHeader[key.toLowerCase()] = headers[key];
+        if (key.toLowerCase() === 'content-type')	{
+          formattedHeader[key.toLowerCase()] = headers[key].toLowerCase();
+        } else {
+          formattedHeader[key.toLowerCase()] = headers[key];
+        }
       }
     });
     return formattedHeader;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paypal/paypalhttp",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A library for integrating with PayPalHttp.",
   "keywords": [
     "paypalhttp",

--- a/spec/unit/encoder_spec.js
+++ b/spec/unit/encoder_spec.js
@@ -144,9 +144,29 @@ describe('encoder', function () {
       assert.deepEqual(deserialized.three, ['one', 'two', 'three']);
     });
 
+    it('deserializes a case insensitive response with content-type == application/JSON', function () {
+      let headers = {
+        'content-type': 'application/JSON; charset=utf8'
+      };
+      let body = '{"one":"two","three":["one","two","three"]}';
+      let deserialized = encoder.deserializeResponse(body, headers);
+
+      assert.equal(deserialized.one, 'two');
+      assert.deepEqual(deserialized.three, ['one', 'two', 'three']);
+    });
+
     it('deserializes a response with content-type == text/*', function () {
       let headers = {
         'content-type': 'text/asdf; charset=utf8'
+      };
+      let body = 'some asdf text';
+
+      assert.equal(encoder.deserializeResponse(body, headers), body);
+    });
+
+    it('deserializes a case insensitive response with content-type == TEXT/*', function () {
+      let headers = {
+        'content-type': 'TEXT/asdf; charset=utf8'
       };
       let body = 'some asdf text';
 

--- a/spec/unit/http_client_spec.js
+++ b/spec/unit/http_client_spec.js
@@ -29,6 +29,24 @@ describe('HttpClient', function () {
     });
   });
 
+  describe('formatHeaders', function () {
+    it('returns formatted headers', function () {
+      let headers = {
+        'Content-Type': 'application/JSON',
+        key: 'value'
+      };
+
+      let expected = {
+        'content-type': 'application/json',
+        key: 'value'
+      };
+
+      let formattedHeaders = this.http.formatHeaders(headers);
+
+      assert.equal(formattedHeaders['content-type'], expected['content-type']);
+    });
+  });
+
   describe('addInjector', function () {
     it('adds to the injectors array', function () {
       function injector(request) {}


### PR DESCRIPTION
Internal Change for Ticket 285: 

Author: hlahlou

Changes made in Encoder and HttpClient to force the value for Content-Type to lowercase.

Added Unit Tests to ensure that deserialization and execution of HTTP request were case insensitive and could handle Content-Types of different casing (ex: application/json vs application/JSON)

Also updated the license, change log, and version to reflect changes made and to update copyright.


Results of Unit Tests:
<img width="964" alt="Screen Shot 2021-08-25 at 12 31 07 PM" src="https://user-images.githubusercontent.com/30755392/130838444-01f944d2-0a93-4907-98cf-b3ccb3cf13cb.png">

Integration Test Results with Checkout SDK:
<img width="1792" alt="Screen Shot 2021-08-30 at 1 19 31 PM" src="https://user-images.githubusercontent.com/30755392/131736813-06563d6e-5428-4d7c-8664-580d4bce6c66.png">
